### PR TITLE
Add mana regen API, encapsulate mana regen calculation

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/api/AureliumAPI.java
+++ b/src/main/java/com/archyx/aureliumskills/api/AureliumAPI.java
@@ -58,6 +58,19 @@ public class AureliumAPI {
         }
     }
 
+    /**
+     * Gets the amount of mana a player regenerates every second
+     * @return the mana regeneration per second of a player
+     */
+    public static double getManaRegen(Player player) {
+        PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
+        if (playerData != null) {
+            return playerData.getManaRegen();
+        } else {
+            return OptionL.getDouble(Option.REGENERATION_BASE_MANA_REGEN);
+        }
+    }
+
     @Deprecated
     public static double getMaxMana(UUID playerId) {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);

--- a/src/main/java/com/archyx/aureliumskills/data/PlayerData.java
+++ b/src/main/java/com/archyx/aureliumskills/data/PlayerData.java
@@ -165,6 +165,10 @@ public class PlayerData {
         return OptionL.getDouble(Option.BASE_MANA) + (OptionL.getDouble(Option.WISDOM_MAX_MANA_PER_WISDOM) * getStatLevel(Stats.WISDOM));
     }
 
+    public double getManaRegen() {
+        return OptionL.getDouble(Option.REGENERATION_BASE_MANA_REGEN) + getStatLevel(Stats.REGENERATION) * OptionL.getDouble(Option.REGENERATION_MANA_MODIFIER);
+    }
+
     public void setMana(double mana) {
         this.mana = mana;
     }

--- a/src/main/java/com/archyx/aureliumskills/mana/ManaManager.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ManaManager.java
@@ -2,10 +2,7 @@ package com.archyx.aureliumskills.mana;
 
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.api.event.ManaRegenerateEvent;
-import com.archyx.aureliumskills.configuration.Option;
-import com.archyx.aureliumskills.configuration.OptionL;
 import com.archyx.aureliumskills.data.PlayerData;
-import com.archyx.aureliumskills.stats.Stats;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -33,7 +30,7 @@ public class ManaManager implements Listener {
                         double maxMana = playerData.getMaxMana();
                         if (originalMana < maxMana) {
                             if (!playerData.getAbilityData(MAbility.ABSORPTION).getBoolean("activated")) {
-                                double regen = OptionL.getDouble(Option.REGENERATION_BASE_MANA_REGEN) + playerData.getStatLevel(Stats.REGENERATION) * OptionL.getDouble(Option.REGENERATION_MANA_MODIFIER);
+                                double regen = playerData.getManaRegen();
                                 double finalRegen = Math.min(originalMana + regen, maxMana) - originalMana;
                                 ManaRegenerateEvent event = new ManaRegenerateEvent(player, finalRegen);
                                 Bukkit.getPluginManager().callEvent(event);


### PR DESCRIPTION
I have a plugin that integrates with Aurelium skills to use and display mana and mana regeneration rates.

I currently have this logic copy+pasted which is not ideal, I thought it'd be nice for myself and other devs to be able to get the regeneration rate without having to know the secret sauce.

Thank you!