### PR TITLE
Add ManaAbilityRefreshEvent

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityReadyEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityReadyEvent.java
@@ -1,0 +1,39 @@
+package com.archyx.aureliumskills.api.event;
+
+import com.archyx.aureliumskills.mana.MAbility;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class ManaAbilityReadyEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Player player;
+    private final MAbility manaAbility;
+
+    public ManaAbilityReadyEvent(Player player, MAbility manaAbility) {
+        this.player = player;
+        this.manaAbility = manaAbility;
+    }
+
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public MAbility getAbility() {
+        return manaAbility;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityRefreshEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityRefreshEvent.java
@@ -23,7 +23,7 @@ public class ManaAbilityReadyEvent extends Event {
         return player;
     }
 
-    public MAbility getAbility() {
+    public MAbility getManaAbility() {
         return manaAbility;
     }
 

--- a/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityRefreshEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityRefreshEvent.java
@@ -6,14 +6,14 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class ManaAbilityReadyEvent extends Event {
+public class ManaAbilityRefreshEvent extends Event {
 
     private static final HandlerList handlers = new HandlerList();
 
     private final Player player;
     private final MAbility manaAbility;
 
-    public ManaAbilityReadyEvent(Player player, MAbility manaAbility) {
+    public ManaAbilityRefreshEvent(Player player, MAbility manaAbility) {
         this.player = player;
         this.manaAbility = manaAbility;
     }

--- a/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityManager.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityManager.java
@@ -1,7 +1,7 @@
 package com.archyx.aureliumskills.mana;
 
 import com.archyx.aureliumskills.AureliumSkills;
-import com.archyx.aureliumskills.api.event.ManaAbilityReadyEvent;
+import com.archyx.aureliumskills.api.event.ManaAbilityRefreshEvent;
 import com.archyx.aureliumskills.configuration.Option;
 import com.archyx.aureliumskills.configuration.OptionL;
 import com.archyx.aureliumskills.configuration.OptionValue;
@@ -190,7 +190,7 @@ public class ManaAbilityManager implements Listener {
                             if (cooldown == 2 || cooldown == 1) {
                                 PlayerData playerData = plugin.getPlayerManager().getPlayerData(id);
                                 if (playerData != null) {
-                                    ManaAbilityReadyEvent event = new ManaAbilityReadyEvent(playerData.getPlayer(), ab);
+                                    ManaAbilityRefreshEvent event = new ManaAbilityRefreshEvent(playerData.getPlayer(), ab);
                                     Bukkit.getPluginManager().callEvent(event);
                                 }
                             }

--- a/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityManager.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityManager.java
@@ -187,7 +187,7 @@ public class ManaAbilityManager implements Listener {
                             } else if (cooldown == 1) {
                                 abilityCooldowns.put(ab, 0);
                             }
-                            if(cooldown == 2 || cooldown == 1) {
+                            if (cooldown == 2 || cooldown == 1) {
                                 PlayerData playerData = plugin.getPlayerManager().getPlayerData(id);
                                 if (playerData != null) {
                                     ManaAbilityReadyEvent event = new ManaAbilityReadyEvent(playerData.getPlayer(), ab);

--- a/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityManager.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityManager.java
@@ -1,6 +1,7 @@
 package com.archyx.aureliumskills.mana;
 
 import com.archyx.aureliumskills.AureliumSkills;
+import com.archyx.aureliumskills.api.event.ManaAbilityReadyEvent;
 import com.archyx.aureliumskills.configuration.Option;
 import com.archyx.aureliumskills.configuration.OptionL;
 import com.archyx.aureliumskills.configuration.OptionValue;
@@ -185,6 +186,13 @@ public class ManaAbilityManager implements Listener {
                                 abilityCooldowns.put(ab, cooldown - 2);
                             } else if (cooldown == 1) {
                                 abilityCooldowns.put(ab, 0);
+                            }
+                            if(cooldown == 2 || cooldown == 1) {
+                                PlayerData playerData = plugin.getPlayerManager().getPlayerData(id);
+                                if (playerData != null) {
+                                    ManaAbilityReadyEvent event = new ManaAbilityReadyEvent(playerData.getPlayer(), ab);
+                                    Bukkit.getPluginManager().callEvent(event);
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
Added this event for a plugin I'm working on that only runs code when an ability's cooldown is finished. Couldn't find anything *documented* about such an event; figured rather than creating my own bukkit task that runs every tick checking all cooldown's it would be more efficient if the plugin just called an event that could be listened to :)

Thanks!