### PR TITLE
improve AureliumSkills instance API

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/api/AureliumAPI.java
+++ b/src/main/java/com/archyx/aureliumskills/api/AureliumAPI.java
@@ -20,8 +20,21 @@ public class AureliumAPI {
 
     private static AureliumSkills plugin;
 
+    /**
+     * Internal usage only.
+     * Sets the {@link AureliumSkills} instance that will be used by all methods.
+     * @param plugin AureliumSkills instance
+     */
     public static void setPlugin(AureliumSkills plugin) {
         AureliumAPI.plugin = plugin;
+    }
+
+    /**
+     * Provides the {@link AureliumSkills} plugin instance.
+     * @return AureliumSkills instance.
+     */
+    public static AureliumSkills getPlugin() {
+        return plugin;
     }
 
     /**

--- a/src/main/java/com/archyx/aureliumskills/api/AureliumAPI.java
+++ b/src/main/java/com/archyx/aureliumskills/api/AureliumAPI.java
@@ -26,14 +26,23 @@ public class AureliumAPI {
      * @param plugin AureliumSkills instance
      */
     public static void setPlugin(AureliumSkills plugin) {
-        AureliumAPI.plugin = plugin;
+        if (AureliumAPI.plugin == null) {
+            AureliumAPI.plugin = plugin;
+        } else {
+            throw new IllegalStateException("The AureliumSkills API is already registered");
+        }
     }
 
     /**
      * Provides the {@link AureliumSkills} plugin instance.
+     * Anything in the AureliumSkills instance is not an official API and could break
+     * between versions without warning. Use at your own risk.
      * @return AureliumSkills instance.
      */
     public static AureliumSkills getPlugin() {
+        if (plugin == null) {
+            throw new IllegalStateException("The AureliumSkills API is not loaded yet");
+        }
         return plugin;
     }
 


### PR DESCRIPTION
* added JavaDocs to setPlugin() that make clear it's for internal usage only

* added a getPlugin() method that returns the instance of AureliumSkills that has been set with setPlugin(). This makes it more convenient for API users to work with non-API classes as it saves them from doing this stuff:
```JAVA
 final AureliumSkills aureliumPlugin;
 final Plugin probablyAurelium = Bukkit.getPluginManager().getPlugin("AureliumSkills");
        try {
            aureliumPlugin = (AureliumSkills) probablyAurelium;
        } catch (final ClassCastException exception) {
            throw new HookException(probablyAurelium, "AureliumSkills wasn't able to be hooked due to another plugin having the same name...");
        }
```