### PR TITLE
Fix Slimefun block placer duping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.Slimefun</groupId>
+            <artifactId>Slimefun4</artifactId>
+            <version>RC-28</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>16.0.1</version>

--- a/src/main/java/com/archyx/aureliumskills/AureliumSkills.java
+++ b/src/main/java/com/archyx/aureliumskills/AureliumSkills.java
@@ -136,6 +136,7 @@ public class AureliumSkills extends JavaPlugin {
 	private boolean townyEnabled;
 	private TownySupport townySupport;
 	private boolean luckPermsEnabled;
+	private boolean slimefunEnabled;
 	private Economy economy;
 	private OptionL optionLoader;
 	private PaperCommandManager commandManager;
@@ -207,6 +208,12 @@ public class AureliumSkills extends JavaPlugin {
 		if (luckPermsEnabled) {
 			luckPermsSupport = new LuckPermsSupport();
 		}
+		// Check for Slimefun
+		slimefunEnabled = Bukkit.getPluginManager().isPluginEnabled("Slimefun");
+		if (slimefunEnabled) {
+			getServer().getPluginManager().registerEvents(new SlimefunSupport(this), this);
+			getLogger().info("Slimefun Support Enabled!");
+		}
 		// Load health
 		Health health = new Health(this);
 		this.health = health;
@@ -234,7 +241,7 @@ public class AureliumSkills extends JavaPlugin {
 			holographicDisplaysEnabled = false;
 		}
 		commandManager = new PaperCommandManager(this);
-		// Load items
+		// Load	 items
 		itemRegistry.loadFromFile();
 		// Load languages
 		lang = new Lang(this);
@@ -733,6 +740,10 @@ public class AureliumSkills extends JavaPlugin {
 
 	public boolean isLuckPermsEnabled() {
 		return luckPermsEnabled;
+	}
+
+	public boolean isSlimefunEnabled() {
+		return slimefunEnabled;
 	}
 
 	public Health getHealth() {

--- a/src/main/java/com/archyx/aureliumskills/support/SlimefunSupport.java
+++ b/src/main/java/com/archyx/aureliumskills/support/SlimefunSupport.java
@@ -1,0 +1,23 @@
+package com.archyx.aureliumskills.support;
+
+import com.archyx.aureliumskills.AureliumSkills;
+import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class SlimefunSupport implements Listener {
+
+    private final AureliumSkills plugin;
+
+    public SlimefunSupport(AureliumSkills plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBlockPlacerPlaceEvent(BlockPlacerPlaceEvent event) {
+        if (!event.isCancelled()) {
+            this.plugin.getRegionManager().addPlacedBlock(event.getBlock());
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: com.archyx.aureliumskills.AureliumSkills
 description: Feature-Packed Skills Plugin
 author: Archyx
 website: https://www.spigotmc.org/resources/aurelium-skills-advanced-skills-stats-abilities-and-more.81069/
-softdepend: [WorldGuard, PlaceholderAPI, HolographicDisplays, Vault, ProtocolLib, LuckPerms]
+softdepend: [WorldGuard, PlaceholderAPI, HolographicDisplays, Vault, ProtocolLib, LuckPerms, Slimefun]
 api-version: '1.13'
 prefix: AureliumSkills
 


### PR DESCRIPTION
Fix the Slimefun block placer duping from #69. 

I added Slimefun to be a soft-dependency and added a listener that listens to the [`BlockPlacerPlaceEvent`](https://github.com/Slimefun/Slimefun4/blob/558bfb5c37fa2983ccc1e06de1f35a0b005a80f5/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/BlockPlacerPlaceEvent.java) from their API. It's called the region manager to add the block of block placer placed for preventing the duping.