### PR TITLE
Allow custom potions to be ignored

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/configuration/Option.java
+++ b/src/main/java/com/archyx/aureliumskills/configuration/Option.java
@@ -150,6 +150,7 @@ public enum Option {
     ALCHEMY_GIVE_XP_ON_TAKEOUT("alchemy.give-xp-on-takeout", OptionType.BOOLEAN),
     ALCHEMY_GIVE_XP_ON_POTION_COMBAT("alchemy.give-xp-on-potion-combat", OptionType.BOOLEAN),
     ALCHEMY_CHECK_MULTIPLIER_PERMISSIONS("alchemy.check-multiplier-permissions", OptionType.BOOLEAN),
+    ALCHEMY_IGNORE_CUSTOM_POTIONS("alchemy.ignore-custom-potions", OptionType.BOOLEAN),
     ENCHANTING_ENABLED("enchanting.enabled", OptionType.BOOLEAN),
     ENCHANTING_MAX_LEVEL("enchanting.max-level", OptionType.INT),
     ENCHANTING_CHECK_CANCELLED("enchanting.check-cancelled", OptionType.BOOLEAN),

--- a/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyAbilities.java
@@ -3,6 +3,8 @@ package com.archyx.aureliumskills.skills.alchemy;
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.ability.Ability;
 import com.archyx.aureliumskills.ability.AbilityProvider;
+import com.archyx.aureliumskills.configuration.Option;
+import com.archyx.aureliumskills.configuration.OptionL;
 import com.archyx.aureliumskills.data.PlayerData;
 import com.archyx.aureliumskills.lang.AbilityMessage;
 import com.archyx.aureliumskills.lang.Lang;
@@ -207,6 +209,7 @@ public class AlchemyAbilities extends AbilityProvider implements Listener {
         if (item.getItemMeta() instanceof PotionMeta && item.getItemMeta() != null) {
             PotionMeta meta = (PotionMeta) item.getItemMeta();
             PotionData potionData = meta.getBasePotionData();
+            if (meta.hasCustomEffects() && OptionL.getBoolean(Option.ALCHEMY_IGNORE_CUSTOM_POTIONS)) return;
             // Get potion duration bonus from Alchemist ability
             NBTItem nbtItem = new NBTItem(item);
             int durationBonus = 0;
@@ -294,6 +297,7 @@ public class AlchemyAbilities extends AbilityProvider implements Listener {
             if (playerData == null) return;
             if (playerData.getAbilityLevel(Ability.LINGERING) > 0) {
                 AreaEffectCloud cloud = event.getAreaEffectCloud();
+                if (cloud.hasCustomEffects() && OptionL.getBoolean(Option.ALCHEMY_IGNORE_CUSTOM_POTIONS)) return;
                 // Get values
                 double naturalDecay = 1 - (getValue(Ability.LINGERING, playerData) / 100);
                 double entityDecay = 1 - (getValue2(Ability.LINGERING, playerData) / 100);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -254,6 +254,7 @@ alchemy:
     give-xp-on-takeout: false
     give-xp-on-potion-combat: false
     check-multiplier-permissions: true
+    ignore-custom-potions: false
 enchanting:
     enabled: true
     max-level: 97


### PR DESCRIPTION
Because `PotionUtil#getDuration()` will default to certain potion lengths, any custom potions with special durations will be effectively overwritten.

This config option, set to false by default to preserve current behaviour, will check if Splash and Lingering Potions have custom effects and opt not to apply Alchemy abilities to them. Such a check isn't required on custom regular potions as they cannot be brewed (doing so causes them to lose their effects anyway).

This should allow better compatibility with other plugins and custom content that uses custom potions.