### PR TITLE
Code cleanup to resolve a few compiler warnings

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/AureliumSkills.java
+++ b/src/main/java/com/archyx/aureliumskills/AureliumSkills.java
@@ -167,6 +167,7 @@ public class AureliumSkills extends JavaPlugin {
 	private MenuFileManager menuFileManager;
 	private ForgingLeveler forgingLeveler;
 
+	@Override
 	public void onEnable() {
 		// Registries
 		statRegistry = new StatRegistry();
@@ -344,6 +345,7 @@ public class AureliumSkills extends JavaPlugin {
 		}
 	}
 	
+    @Override
 	public void onDisable() {
 		for (PlayerData playerData : playerManager.getPlayerDataMap().values()) {
 			storageProvider.save(playerData.getPlayer(), false);

--- a/src/main/java/com/archyx/aureliumskills/lang/AbilityMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/AbilityMessage.java
@@ -252,6 +252,7 @@ public enum AbilityMessage implements MessageKey {
         path = "abilities." + ability.getSkill().name().toLowerCase(Locale.ENGLISH) + "." + ability.name().toLowerCase(Locale.ENGLISH) + "." + this.name().substring(ability.name().length() + 1).toLowerCase(Locale.ENGLISH);
     }
 
+    @Override
     public String getPath() {
         return path;
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/ActionBarMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/ActionBarMessage.java
@@ -13,6 +13,7 @@ public enum ActionBarMessage implements MessageKey {
     BOSS_BAR_XP,
     BOSS_BAR_MAXED;
 
+    @Override
     public String getPath() {
         return "action_bar." + this.toString().toLowerCase(Locale.ENGLISH);
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/CommandMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/CommandMessage.java
@@ -158,6 +158,7 @@ public enum CommandMessage implements MessageKey {
         this.path = "commands." + path;
     }
 
+    @Override
     public String getPath() {
         return path;
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/LevelerMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/LevelerMessage.java
@@ -15,6 +15,7 @@ public enum LevelerMessage implements MessageKey {
     MONEY_REWARD,
     UNCLAIMED_ITEM;
 
+    @Override
     public String getPath() {
         return "leveler." + this.toString().toLowerCase(Locale.ENGLISH);
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/ManaAbilityMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/ManaAbilityMessage.java
@@ -67,6 +67,7 @@ public enum ManaAbilityMessage implements MessageKey {
         this.path = "mana_abilities." + path;
     }
 
+    @Override
     public String getPath() {
         return path;
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/MenuMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/MenuMessage.java
@@ -131,6 +131,7 @@ public enum MenuMessage implements MessageKey {
         }
     }
 
+    @Override
     public String getPath() {
         return path;
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/SkillMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/SkillMessage.java
@@ -41,6 +41,7 @@ public enum SkillMessage implements MessageKey {
     private final Skill skill = Skills.valueOf(this.name().substring(0, this.name().lastIndexOf("_")));
     private final String path = "skills." + skill.name().toLowerCase(Locale.ENGLISH) + "." + this.name().substring(this.name().lastIndexOf("_") + 1).toLowerCase(Locale.ENGLISH);
 
+    @Override
     public String getPath() {
         return path;
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/StatMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/StatMessage.java
@@ -35,6 +35,7 @@ public enum StatMessage implements MessageKey {
     private final Stat stat = Stats.valueOf(this.name().substring(0, this.name().lastIndexOf("_")));
     private final String path = "stats." + stat.toString().toLowerCase(Locale.ENGLISH) + "." + this.toString().substring(this.name().lastIndexOf("_") + 1).toLowerCase(Locale.ENGLISH);
     
+    @Override
     public String getPath() {
         return path;
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/UnitMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/UnitMessage.java
@@ -10,6 +10,7 @@ public enum UnitMessage implements MessageKey {
 
     private final String path = "units." + this.toString().toLowerCase(Locale.ENGLISH);
 
+    @Override
     public String getPath() {
         return path;
     }

--- a/src/main/java/com/archyx/aureliumskills/listeners/DamageListener.java
+++ b/src/main/java/com/archyx/aureliumskills/listeners/DamageListener.java
@@ -96,6 +96,8 @@ public class DamageListener implements Listener {
                 case SHOVEL:
                     excavationAbilities.spadeMaster(event, player, playerData);
                     break;
+                default:
+                    break;
             }
 
             //First strike

--- a/src/main/java/com/archyx/aureliumskills/mana/Treecapitator.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/Treecapitator.java
@@ -193,6 +193,8 @@ public class Treecapitator extends ReadiedManaAbility {
                     case DARK_OAK_LOG:
                         maxBlocks = 150;
                         break;
+                    default:
+                        break;
                 }
             } else {
                 maxBlocks = 100;

--- a/src/main/java/com/archyx/aureliumskills/skills/Skill.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/Skill.java
@@ -21,6 +21,7 @@ public interface Skill {
 
     String name();
 
+    @Override
     String toString();
 
     Ability getXpMultiplierAbility();

--- a/src/main/java/com/archyx/aureliumskills/util/armor/ArmorEquipEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/util/armor/ArmorEquipEvent.java
@@ -56,6 +56,7 @@ public final class ArmorEquipEvent extends PlayerEvent implements Cancellable{
      *
      * @param cancel If this event should be cancelled.
      */
+    @Override
     public final void setCancelled(final boolean cancel){
         this.cancel = cancel;
     }
@@ -65,6 +66,7 @@ public final class ArmorEquipEvent extends PlayerEvent implements Cancellable{
      *
      * @return If this event is cancelled
      */
+    @Override
     public final boolean isCancelled(){
         return cancel;
     }

--- a/src/main/java/com/archyx/aureliumskills/util/mechanics/PotionUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/mechanics/PotionUtil.java
@@ -89,6 +89,8 @@ public class PotionUtil {
             case INSTANT_DAMAGE:
             case WEAKNESS:
                 return true;
+            default:
+                break;
         }
         return false;
     }


### PR DESCRIPTION
Code cleanup to resolve a few compiler warnings. Fixed enum incomplete switch missing corresponding default label. Fixed several instances of missing `@Override` annotations.
