### PR TITLE
Logic error in Sharp Hook world validation

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/mana/SharpHook.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/SharpHook.java
@@ -126,7 +126,7 @@ public class SharpHook extends ManaAbilityProvider {
         // Disallow if in different worlds
         World damagerWorld = damagerLocation.getWorld();
         World hookedWorld = hookedLocation.getWorld();
-        if (damagerWorld != null & hookedWorld != null) {
+        if (damagerWorld != null && hookedWorld != null) {
             if (!damagerWorld.equals(hookedWorld)) {
                 return false;
             }


### PR DESCRIPTION
Fixes a logic error where a bitwise AND (&) was used instead of logical AND (&&).
