### PR TITLE
Cancel Out Block Loot if Slimefun Block

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/loot/handler/BlockLootHandler.java
+++ b/src/main/java/com/archyx/aureliumskills/loot/handler/BlockLootHandler.java
@@ -13,6 +13,7 @@ import com.archyx.lootmanager.loot.LootPool;
 import com.archyx.lootmanager.loot.LootTable;
 import com.archyx.lootmanager.loot.type.CommandLoot;
 import com.archyx.lootmanager.loot.type.ItemLoot;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import org.bukkit.GameMode;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -54,6 +55,12 @@ public abstract class BlockLootHandler extends LootHandler implements Listener {
 
         if (plugin.isWorldGuardEnabled()) {
             if (plugin.getWorldGuardSupport().blockedByFlag(block.getLocation(), player, WorldGuardFlags.FlagKey.CUSTOM_LOOT)) {
+                return;
+            }
+        }
+
+        if (plugin.isSlimefunEnabled()) {
+            if (BlockStorage.hasBlockInfo(block.getLocation())) {
                 return;
             }
         }


### PR DESCRIPTION
This commit would prevent aurelium skills from overriding a slimefun block drop by blockstorage.