### PR TITLE
Remove world hard reference from Region

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/region/Region.java
+++ b/src/main/java/com/archyx/aureliumskills/region/Region.java
@@ -3,13 +3,15 @@ package com.archyx.aureliumskills.region;
 import org.bukkit.World;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class Region {
 
-    private final World world;
+    private final WeakReference<World> world;
+    private final String worldName;
     private final int x;
     private final int z;
     private final ConcurrentMap<ChunkCoordinate, ChunkData> chunks;
@@ -17,7 +19,8 @@ public class Region {
     private boolean loading;
 
     public Region(World world, int x, int z) {
-        this.world = world;
+        this.world = new WeakReference<>(world);
+        this.worldName = world.getName();
         this.x = x;
         this.z = z;
         this.chunks = new ConcurrentHashMap<>();
@@ -25,8 +28,13 @@ public class Region {
         this.loading = false;
     }
 
+    @Nullable
     public World getWorld() {
-        return world;
+        return world.get();
+    }
+
+    public String getWorldName() {
+        return worldName;
     }
 
     public int getX() {

--- a/src/main/java/com/archyx/aureliumskills/region/RegionCoordinate.java
+++ b/src/main/java/com/archyx/aureliumskills/region/RegionCoordinate.java
@@ -5,18 +5,24 @@ import org.bukkit.World;
 
 public class RegionCoordinate {
 
-    private final World world;
+    private final String worldName;
     private final int x;
     private final int z;
 
     public RegionCoordinate(World world, int x, int z) {
-        this.world = world;
+        this.worldName = world.getName();
         this.x = x;
         this.z = z;
     }
 
-    public World getWorld() {
-        return world;
+    public RegionCoordinate(String worldName, int x, int z) {
+        this.worldName = worldName;
+        this.x = x;
+        this.z = z;
+    }
+
+    public String getWorldName() {
+        return worldName;
     }
 
     public int getX() {
@@ -37,18 +43,18 @@ public class RegionCoordinate {
             return false;
         } else {
             RegionCoordinate other = (RegionCoordinate) obj;
-            return this.x == other.x && this.z == other.z && this.world == other.world;
+            return this.x == other.x && this.z == other.z && this.worldName.equals(other.worldName);
         }
     }
 
     @Override
     public String toString() {
-        return world.getName() + ", " + x + ", " + z;
+        return worldName + ", " + x + ", " + z;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(world.getName(), x, z);
+        return Objects.hashCode(worldName, x, z);
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/region/RegionManager.java
+++ b/src/main/java/com/archyx/aureliumskills/region/RegionManager.java
@@ -102,11 +102,11 @@ public class RegionManager {
     public void loadRegion(Region region) {
         if (region.isLoading()) return;
         region.setLoading(true);
-        RegionCoordinate regionCoordinate = new RegionCoordinate(region.getWorld(), region.getX(), region.getZ());
-        World world = regionCoordinate.getWorld();
+        RegionCoordinate regionCoordinate = new RegionCoordinate(region.getWorldName(), region.getX(), region.getZ());
+        String worldName = regionCoordinate.getWorldName();
         int regionX = regionCoordinate.getX();
         int regionZ = regionCoordinate.getZ();
-        File file = new File(plugin.getDataFolder() + "/regiondata/" + world.getName() + "/r." + regionX + "." + regionZ + ".asrg");
+        File file = new File(plugin.getDataFolder() + "/regiondata/" + worldName + "/r." + regionX + "." + regionZ + ".asrg");
         if (file.exists()) {
             if (saving) {
                 region.setReload(true);
@@ -154,13 +154,13 @@ public class RegionManager {
         region.setChunkData(chunkCoordinate, chunkData);
     }
 
-    private void saveRegion(World world, int regionX, int regionZ) throws IOException {
-        RegionCoordinate regionCoordinate = new RegionCoordinate(world, regionX, regionZ);
+    private void saveRegion(String worldName, int regionX, int regionZ) throws IOException {
+        RegionCoordinate regionCoordinate = new RegionCoordinate(worldName, regionX, regionZ);
         Region region = getRegion(regionCoordinate);
         if (region == null) return;
         if (region.getChunkMap().size() == 0) return;
 
-        File file = new File(plugin.getDataFolder() + "/regiondata/" + world.getName() + "/r." + regionX + "." + regionZ + ".asrg");
+        File file = new File(plugin.getDataFolder() + "/regiondata/" + worldName + "/r." + regionX + "." + regionZ + ".asrg");
         try {
             NBTFile nbtFile = new NBTFile(file);
 
@@ -211,11 +211,11 @@ public class RegionManager {
         saving = true;
         for (Region region : regions.values()) {
             try {
-                saveRegion(region.getWorld(), region.getX(), region.getZ());
+                saveRegion(region.getWorldName(), region.getX(), region.getZ());
                 // Clear region from memory if no chunks are loaded in it
                 if (clearUnused) {
                     if (isRegionUnused(region)) {
-                        regions.remove(new RegionCoordinate(region.getWorld(), region.getX(), region.getZ()));
+                        regions.remove(new RegionCoordinate(region.getWorldName(), region.getX(), region.getZ()));
                     }
                 }
             } catch (Exception e) {
@@ -232,7 +232,7 @@ public class RegionManager {
     private boolean isRegionUnused(Region region) {
         for (int chunkX = region.getX() * 32; chunkX < region.getX() * 32 + 32; chunkX++) {
             for (int chunkZ = region.getZ() * 32; chunkZ < region.getZ() * 32 + 32; chunkZ++) {
-                if (region.getWorld().isChunkLoaded(chunkX, chunkZ)) {
+                if (region.getWorld() == null || region.getWorld().isChunkLoaded(chunkX, chunkZ)) {
                     return false;
                 }
             }


### PR DESCRIPTION
It can cause memory leak when world was unloaded or deleted, now `Region` use weak reference of `World` for removing region when world was unloaded and garbage collected.