### PR TITLE
Fix piercing on non-lethal arrow damage

### DIFF
--- a/bukkit/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryAbilities.java
+++ b/bukkit/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryAbilities.java
@@ -15,6 +15,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
@@ -94,12 +95,14 @@ public class ArcheryAbilities extends AbilityProvider implements Listener {
         }
         if (r.nextDouble() < (getValue(Ability.PIERCING, playerData) / 100)) {
             arrow.setBounce(false);
-            Vector velocity = arrow.getVelocity();
-            Arrow newArrow = event.getEntity().getWorld().spawnArrow(arrow.getLocation(), velocity, (float) velocity.length(), 0.0f);
-            newArrow.setShooter(player);
-            newArrow.setKnockbackStrength(arrow.getKnockbackStrength());
-            newArrow.setFireTicks(arrow.getFireTicks());
-            newArrow.setPickupStatus(AbstractArrow.PickupStatus.CREATIVE_ONLY);
+            arrow.setPierceLevel(arrow.getPierceLevel() + 1);
+        }
+    }
+
+    public void pierceInit(PlayerData playerData, Player player, Arrow arrow) {
+        if (r.nextDouble() < (getValue(Ability.PIERCING, playerData) / 100)) {
+            // Adds 1 pierce to the initial shot otherwise it doesn't pierce on non-lethal damage.
+            arrow.setPierceLevel(arrow.getPierceLevel() + 1);
         }
     }
 
@@ -123,6 +126,24 @@ public class ArcheryAbilities extends AbilityProvider implements Listener {
                     }
                     if (options.isEnabled(Ability.PIERCING)) {
                         piercing(event, playerData, player, arrow);
+                    }
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void pierceListener(EntityShootBowEvent event) {
+        if (OptionL.isEnabled(Skills.ARCHERY)) {
+            if (event.getProjectile() instanceof Arrow) {
+                Arrow arrow = (Arrow) event.getProjectile();
+                if (arrow.getShooter() instanceof Player) {
+                    Player player = (Player) arrow.getShooter();
+                    PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
+                    if (playerData == null) return;
+                    AbilityManager options = plugin.getAbilityManager();
+                    if (options.isEnabled(Ability.PIERCING)) {
+                        pierceInit(playerData, player, arrow);
                     }
                 }
             }

--- a/bukkit/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryAbilities.java
+++ b/bukkit/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryAbilities.java
@@ -10,7 +10,10 @@ import com.archyx.aureliumskills.skills.Skills;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.attribute.AttributeModifier;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -18,7 +21,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.util.Vector;
 
 import java.util.Random;
 
@@ -100,6 +102,7 @@ public class ArcheryAbilities extends AbilityProvider implements Listener {
     }
 
     public void pierceInit(PlayerData playerData, Player player, Arrow arrow) {
+        if (blockAbility(player)) return;
         if (r.nextDouble() < (getValue(Ability.PIERCING, playerData) / 100)) {
             // Adds 1 pierce to the initial shot otherwise it doesn't pierce on non-lethal damage.
             arrow.setPierceLevel(arrow.getPierceLevel() + 1);


### PR DESCRIPTION
Addresses piercing in https://github.com/Archy-X/AureliumSkills/issues/191

Arrows were originally bouncing off of entities if they didn't kill them during a pierce attempt, likely due to invulnerability after being damaged.

Removed the copying of arrows that simulated piercing to get rid of arrows bouncing off entities on non-lethal hits and instead adds 1 to pierceLevel of arrows that do pierce.
Rolls a pierce attempt when an arrow is shot from a bow/crossbow to ensure that the first pierce is successful.

Tested by lining up cows and shooting them with 100% pierce using unenchanted bows and crossbows.