### PR TITLE
Configuration - Reset just skill xp on death (reset-xp-on-death)

### DIFF
--- a/bukkit/src/main/java/com/archyx/aureliumskills/configuration/Option.java
+++ b/bukkit/src/main/java/com/archyx/aureliumskills/configuration/Option.java
@@ -62,6 +62,7 @@ public enum Option {
     CHECK_BLOCK_REPLACE("check-block-replace", OptionType.BOOLEAN),
     DISABLE_IN_CREATIVE_MODE("disable-in-creative-mode", OptionType.BOOLEAN),
     RESET_SKILLS_ON_DEATH("reset-skills-on-death", OptionType.BOOLEAN),
+    RESET_XP_ON_DEATH("reset-xp-on-death", OptionType.BOOLEAN),
     AUTO_SAVE_ENABLED("auto-save.enabled", OptionType.BOOLEAN),
     AUTO_SAVE_INTERVAL_TICKS("auto-save.interval-ticks", OptionType.INT),
     SKILL_MONEY_REWARDS_ENABLED("skill-money-rewards.enabled", OptionType.BOOLEAN),

--- a/bukkit/src/main/java/com/archyx/aureliumskills/listeners/PlayerDeath.java
+++ b/bukkit/src/main/java/com/archyx/aureliumskills/listeners/PlayerDeath.java
@@ -22,13 +22,17 @@ public class PlayerDeath implements Listener {
 
 	@EventHandler
 	public void onPlayerDeath(PlayerDeathEvent event) {
-		if (OptionL.getBoolean(Option.RESET_SKILLS_ON_DEATH)) {
+		if (OptionL.getBoolean(Option.RESET_SKILLS_ON_DEATH) || OptionL.getBoolean(Option.RESET_XP_ON_DEATH)) {
 			Player player = event.getEntity();
 			PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
 			if (playerData != null){
 				for (Skill s : plugin.getSkillRegistry().getSkills()) {
-					resetPlayerSkills(player, playerData, s);
-    				}
+					if (OptionL.getBoolean(Option.RESET_SKILLS_ON_DEATH)) {
+						resetPlayerSkills(player, playerData, s);
+					} else if (OptionL.getBoolean(Option.RESET_XP_ON_DEATH)) {
+						resetPlayerXp(playerData, s);
+					}
+    			}
 			}
 		}
 	}
@@ -42,4 +46,7 @@ public class PlayerDeath implements Listener {
 		plugin.getLeveler().applyRevertCommands(player, skill, oldLevel, 1);
 	}
 
+	private void resetPlayerXp(PlayerData playerData, Skill skill) {
+		playerData.setSkillXp(skill, 0);
+	}
 }

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -133,6 +133,7 @@ disabled-worlds:
 
 disable-in-creative-mode: false
 reset-skills-on-death: false
+reset-xp-on-death: false
 
 auto-save:
     enabled: false


### PR DESCRIPTION

The pre-existing `reset-skills-on-death` config had the following behavior when true:
- reset all skill levels to 1
- reset all skill XP to 0

This new config value, `reset-xp-on-death`, allows for a subset of that behavior, as follows:
- reset all skill XP to 0